### PR TITLE
Support string datapoints

### DIFF
--- a/datapoint/datapoint.go
+++ b/datapoint/datapoint.go
@@ -30,19 +30,18 @@ func (p *Datapoint) UnmarshalJSON(bs []byte) error {
 		return errors.New("Not a datapoint")
 	}
 	values := strings.Split(strings.Trim(s, "[]"), ",")
-	if len(values) != 3 {
-		return errors.New("Not a datapoint")
-	}
+
 	timestamp, err := strconv.ParseInt(values[0], 10, 64)
 	if err != nil {
 		return nil
 	}
 	p.Timestamp = time.Unix(0, timestamp*int64(time.Millisecond))
-	p.Measure, err = measurement.FromString(values[1])
+	lastElement := len(values) - 1
+	p.Measure, err = measurement.FromString(strings.Join(values[1:lastElement], ","))
 	if err != nil {
 		return err
 	}
-	q, err := strconv.Atoi(values[2])
+	q, err := strconv.Atoi(values[len(values)-1])
 	if err != nil {
 		return err
 	}

--- a/measurement/convert.go
+++ b/measurement/convert.go
@@ -31,7 +31,7 @@ func FromString(s string) (Measurement, error) {
 			}
 			return Double(floatMeasure), nil
 		default:
-			return nil, err
+			return String(s), nil
 		}
 	default:
 		return nil, err

--- a/measurement/measurement.go
+++ b/measurement/measurement.go
@@ -9,6 +9,7 @@ type Int int
 type Longint int64
 type Float float32
 type Double float64
+type String string
 
 type Measurement interface {
 	Value() string
@@ -28,4 +29,8 @@ func (m Float) Value() string {
 
 func (m Double) Value() string {
 	return fmt.Sprintf("%g", m)
+}
+
+func (m String) Value() string {
+	return string(m)
 }


### PR DESCRIPTION

Predix Timeseries can be used to store string as well.